### PR TITLE
Add ability to cancel reminders

### DIFF
--- a/factory.service.js
+++ b/factory.service.js
@@ -6,114 +6,132 @@ const {cronify} = require('./utils');
 
 const make = (cache, twitter) => {
 
-        const parseReminderTime = (tweet) => {
-            const refDate = new Date(tweet.created_at);
-            let results = chrono.parse(tweet.text, refDate, {forwardDate: true});
-            if (results.length) {
-                results[0].start.assign('timezoneOffset', tweet.utcOffset/60);
-                const reminderTime = results[0].start.date();
-                if (reminderTime > refDate && reminderTime > new Date) {
-                    return {
-                        remindAt: reminderTime,
-                        tweet
-                    };
-                } else {
-                    return {
-                        error: "TIME_IN_PAST",
-                        tweet
-                    };
-                }
+    const parseReminderTime = (tweet) => {
+        const refDate = new Date(tweet.created_at);
+        let results = chrono.parse(tweet.text, refDate, {forwardDate: true});
+        if (results.length) {
+            results[0].start.assign('timezoneOffset', tweet.utcOffset / 60);
+            const reminderTime = results[0].start.date();
+            if (reminderTime > refDate && reminderTime > new Date) {
+                return {
+                    remindAt: reminderTime,
+                    tweet
+                };
             } else {
                 return {
-                    error: "PARSE_TIME_FAILURE",
+                    error: "TIME_IN_PAST",
                     tweet
                 };
             }
-        };
-
-        const scheduleLambda = async (scheduleAt, data) => {
-            const AWS = require('aws-sdk');
-            const cwevents = new AWS.CloudWatchEvents({region: 'us-east-1'});
-
-            const ruleName = process.env.LAMBDA_FUNCTION_NAME + '-' + Date.now() + '-' + Math.random().toString(36).replace(/[^a-z]+/g, '').substr(0, 5);
-            const ruleParams = {
-                Name: ruleName,
-                ScheduleExpression: scheduleAt,
-                State: 'ENABLED'
+        } else {
+            return {
+                error: "PARSE_TIME_FAILURE",
+                tweet
             };
-
-            await cwevents.putRule(ruleParams).promise();
-
-            const input = {data, ruleName};
-            const targetParams = {
-                Rule: ruleName,
-                Targets: [
-                    {
-                        Arn: process.env.LAMBDA_FUNCTION_ARN,
-                        Id: ruleName,
-                        Input: JSON.stringify(input)
-                    }
-                ],
-            };
-            return cwevents.putTargets(targetParams).promise()
-                .then(r => {
-                    console.log(r);
-                    return {ruleName, status: 'SUCCESS'};
-                })
-                .catch(r => {
-                    console.log(r);
-                    return {ruleName, status: 'FAIL'};
-                });
-        };
-
-        const scheduleReminder = (tweet, date) => {
-            return scheduleLambda(cronify(date), tweet);
-        };
-
-        const notifyUserOfReminder = (tweet, date) => {
-            return twitter.replyWithAcknowledgement(tweet, date);
-        };
-
-        const handleParsingResult = async (result) => {
-            console.log(result)
-            if (result.remindAt) {
-                return await Promise.all([
-                    cache.lpushAsync('PARSE_SUCCESS', [JSON.stringify(result.tweet)]),
-                    scheduleReminder(result.tweet, result.remindAt),
-                    notifyUserOfReminder(result.tweet, result.remindAt),
-                ]);
-            } else {
-                await cache.lpushAsync(result.error, [JSON.stringify(result.tweet)]);
-                return result.error;
-            }
-        };
-
-        const cleanup = (ruleName) => {
-            const AWS = require('aws-sdk');
-            const cwevents = new AWS.CloudWatchEvents({region: 'us-east-1'});
-            return cwevents.removeTargets({
-                Rule: ruleName,
-                Ids: [ruleName]
-            })
-                .promise()
-                .then(() => cwevents.deleteRule({Name: ruleName}).promise())
-                .then(r => {
-                    console.log(r);
-                    return {status: 'SUCCESS'};
-                })
-                .catch(r => {
-                    console.log(r);
-                    return {status: 'FAIL'};
-                });
-        };
-
-        return {
-            cleanup,
-            scheduleLambda,
-            handleParsingResult,
-            parseReminderTime,
-            scheduleReminder
         }
+    };
+
+    const cancelReminder = async (tweet) => {
+        const ruleName = await cache.getAsync(tweet.referencing_tweet);
+        if (ruleName) {
+            return await unscheduleLambda(ruleName);
+        }
+        return true;
+    };
+
+    const handleMention = (tweet) => {
+        return tweet.text.match(/\bcancel\b/i) ? cancelReminder(tweet) : parseReminderTime(tweet);
+    };
+
+    const scheduleLambda = async (scheduleAt, data, ruleName) => {
+        const AWS = require('aws-sdk');
+        const cwevents = new AWS.CloudWatchEvents({region: 'us-east-1'});
+        const ruleParams = {
+            Name: ruleName,
+            ScheduleExpression: scheduleAt,
+            State: 'ENABLED'
+        };
+
+        await cwevents.putRule(ruleParams).promise();
+
+        const input = {data, ruleName};
+        const targetParams = {
+            Rule: ruleName,
+            Targets: [
+                {
+                    Arn: process.env.LAMBDA_FUNCTION_ARN,
+                    Id: ruleName,
+                    Input: JSON.stringify(input)
+                }
+            ],
+        };
+        return cwevents.putTargets(targetParams).promise()
+            .then(r => {
+                console.log(r);
+                return {ruleName, status: 'SUCCESS'};
+            })
+            .catch(r => {
+                console.log(r);
+                return {ruleName, status: 'FAIL'};
+            });
+    };
+
+    const scheduleReminder = (tweet, date, ruleName) => {
+        return scheduleLambda(cronify(date), tweet, ruleName);
+    };
+
+    const notifyUserOfReminder = (tweet, date) => {
+        return twitter.replyWithAcknowledgement(tweet, date)
+            .then(r => r.id_str);
+    };
+
+    const handleParsingResult = async (result) => {
+        console.log(result)
+        if (result.remindAt) {
+            const ruleName = process.env.LAMBDA_FUNCTION_NAME + '-' + Date.now() + '-' + Math.random().toString(36).replace(/[^a-z]+/g, '').substr(0, 5);
+            return await Promise.all([
+                cache.lpushAsync('PARSE_SUCCESS', [JSON.stringify(result.tweet)]),
+                scheduleReminder(result.tweet, result.remindAt, ruleName),
+                notifyUserOfReminder(result.tweet, result.remindAt).then(tweetId =>
+                    // cache the link to the reminder so we can delete it if user replies "cancel"
+                    // set TTL so it auto deletes when reminder time is up
+                    cache.setAsync(tweetId, ruleName, 'PX', result.remindAt - Date.now())
+                ),
+            ]);
+        } else {
+            await cache.lpushAsync(result.error, [JSON.stringify(result.tweet)]);
+            return result.error;
+        }
+    };
+
+    const unscheduleLambda = (ruleName) => {
+        const AWS = require('aws-sdk');
+        const cwevents = new AWS.CloudWatchEvents({region: 'us-east-1'});
+        return cwevents.removeTargets({
+            Rule: ruleName,
+            Ids: [ruleName]
+        }).promise()
+            .then(() => cwevents.deleteRule({Name: ruleName}).promise());
+    };
+
+    const cleanup = (ruleName) => {
+        return unscheduleLambda(ruleName)
+            .then(r => {
+                console.log(r);
+                return {status: 'SUCCESS'};
+            }).catch(r => {
+            console.log(r);
+            return {status: 'FAIL'};
+        });
+    };
+
+    return {
+        cleanup,
+        scheduleLambda,
+        handleParsingResult,
+        parseReminderTime,
+        handleMention
+    }
 };
 
 module.exports = make;

--- a/factory.twitter.js
+++ b/factory.twitter.js
@@ -57,7 +57,7 @@ module.exports = (cache) => {
                     console.log(JSON.stringify(r.data.errors));
                     return cache.setAsync('no-reply', 1, 'EX', 10 * 60).then(() => r);
                 }
-                return r;
+                return r.data;
             });
     };
 

--- a/handler.js
+++ b/handler.js
@@ -12,7 +12,7 @@ module.exports.fetchTweetsAndSetReminders = async (event, context, callback) => 
 
     const allMentions = await twitter.fetchAllMentions();
 
-    let results = allMentions.map(service.parseReminderTime);
+    let results = allMentions.map(service.handleMention);
     await Promise.all(results.map(service.handleParsingResult));
 
     finish(callback, cache).success(`Handled ${allMentions.length} tweets`);

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,10 +47,9 @@
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "aws-sdk": {
-      "version": "2.373.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.373.0.tgz",
-      "integrity": "sha512-NZYXwXGtFt9jxaKXc+PJsLPnpbD03t0MAZRxh93g36kbFMuRXtY8CDqHYNQ0ZcrgQpXbCQiz1fxT5/wu5Cu70g==",
-      "dev": true,
+      "version": "2.376.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.376.0.tgz",
+      "integrity": "sha512-7/xsLzgF0GJIFTy2qPmn+dFLQoBpWponm+FS9aHUmjI0UMiTieBJzHUSZ8BHIY/4JukBLc3B5hL5evW+NS4pzw==",
       "requires": {
         "buffer": "4.9.1",
         "events": "1.1.1",
@@ -66,8 +65,7 @@
         "uuid": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
-          "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g==",
-          "dev": true
+          "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g=="
         }
       }
     },
@@ -90,8 +88,7 @@
     "base64-js": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.0.tgz",
-      "integrity": "sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw==",
-      "dev": true
+      "integrity": "sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw=="
     },
     "bcrypt-pbkdf": {
       "version": "1.0.2",
@@ -126,7 +123,6 @@
       "version": "4.9.1",
       "resolved": "http://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
       "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
-      "dev": true,
       "requires": {
         "base64-js": "^1.0.2",
         "ieee754": "^1.1.4",
@@ -295,8 +291,7 @@
     "events": {
       "version": "1.1.1",
       "resolved": "http://registry.npmjs.org/events/-/events-1.1.1.tgz",
-      "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=",
-      "dev": true
+      "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ="
     },
     "extend": {
       "version": "3.0.2",
@@ -429,8 +424,7 @@
     "ieee754": {
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.8.tgz",
-      "integrity": "sha1-vjPUCsEO8ZJnAfbwii2G+/0a0+Q=",
-      "dev": true
+      "integrity": "sha1-vjPUCsEO8ZJnAfbwii2G+/0a0+Q="
     },
     "inflight": {
       "version": "1.0.6",
@@ -456,8 +450,7 @@
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-      "dev": true
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
     "isstream": {
       "version": "0.1.2",
@@ -467,8 +460,7 @@
     "jmespath": {
       "version": "0.15.0",
       "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
-      "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc=",
-      "dev": true
+      "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc="
     },
     "jsbn": {
       "version": "0.1.1",
@@ -649,8 +641,7 @@
     "querystring": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
-      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
-      "dev": true
+      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
     },
     "redis": {
       "version": "2.8.0",
@@ -712,8 +703,7 @@
     "sax": {
       "version": "1.2.1",
       "resolved": "http://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
-      "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o=",
-      "dev": true
+      "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o="
     },
     "serverless-dotenv-plugin": {
       "version": "2.0.1",
@@ -924,7 +914,6 @@
       "version": "0.10.3",
       "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
       "integrity": "sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=",
-      "dev": true,
       "requires": {
         "punycode": "1.3.2",
         "querystring": "0.2.0"
@@ -933,8 +922,7 @@
         "punycode": {
           "version": "1.3.2",
           "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
-          "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=",
-          "dev": true
+          "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
         }
       }
     },
@@ -963,7 +951,6 @@
       "version": "0.4.19",
       "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
       "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
-      "dev": true,
       "requires": {
         "sax": ">=0.6.0",
         "xmlbuilder": "~9.0.1"
@@ -972,8 +959,7 @@
     "xmlbuilder": {
       "version": "9.0.7",
       "resolved": "http://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
-      "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=",
-      "dev": true
+      "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
     },
     "yaml-edit": {
       "version": "0.1.3",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "dependencies": {
+    "aws-sdk": "^2.376.0",
     "chrono-node": "^1.3.5",
     "redis": "^2.8.0",
     "twit": "^2.2.11"

--- a/utils.js
+++ b/utils.js
@@ -33,10 +33,12 @@ const randomReminderMessage = (username) => {
 
 const randomAcknowledgementMessage = (reminderTime, username) => {
     let responses = [
-        `Sure thing! I'll remind you of this tweet at ${reminderTime.toUTCString()}. 😃`,
+        `Sure thing! I'll remind you of this tweet at ${reminderTime.toUTCString()}.😃`,
         `Got it, @${username}! I'll remind you about this at ${reminderTime.toUTCString()}.🤗`,
     ];
-    return responses[Math.floor(Math.random() * responses.length)];
+    let message = responses[Math.floor(Math.random() * responses.length)];
+    message += ' Reply "cancel" to this message to cancel this reminder.';
+    return message;
 };
 
 const dateToCronExpression = (date) => {


### PR DESCRIPTION
This implementation depends on the bot having successfully posted a reply to the user. The name of the CloudWatch rule is stored in Redis, with the ID of the bot's reply as the key. If the user replies "cancel" to the message, the bot will look up the tweet and cancel the associated rule. Alternatively, the Redis entry will expire when the reminder expires.

I know this implementation is tied to a successful reply, but I don't anticipate such high usage as for this_vid. If I need to, I'll rework it later.  The key difficulty is storing state across tweets (a "cancel" tweet contains only information about itself; other than the reply ID, there's no direct way to find out the referenced reminder) while optimising speed by minimizing requests and batching as many requests as possible.