### PR TITLE
fix: get tweet text from the proper argument

### DIFF
--- a/handler.js
+++ b/handler.js
@@ -61,7 +61,7 @@ module.exports.handleAccountActivity = async (event, context) => {
         return {
             id: tweetObject.id_str,
             created_at: tweetObject.created_at,
-            text: tweetObject.full_text || tweetObject.text,
+            text: tweet.truncated ? tweetObject.extended_tweet.full_text || tweetObject.text,
             referencing_tweet: tweetObject.in_reply_to_status_id_str,
             author: tweetObject.user.screen_name,
         };


### PR DESCRIPTION
I trust that this project uses [Twitter's Premium API v1.1](https://developer.twitter.com/en/docs/twitter-api).

According to the same documentation at [Twitter's Premium API v1.1 Data Dictionary](https://developer.twitter.com/en/docs/twitter-api/premium/data-dictionary/overview), under the **Extended Tweets** section, it says

>  When true (`"truncated": true`), the "extended_tweet" fields should be parsed instead of the root-level fields.

The changes in this PR make sure that the tweet text is gotten from the extended tweet if it is available, else, it is gotten from `tweetObject` itself.

Nice work here!