### PR TITLE
prevent scheduling >=30 years into the future

### DIFF
--- a/src/factory.service.js
+++ b/src/factory.service.js
@@ -27,7 +27,7 @@ const makeService = (cache, twitter, notifications) => {
             // Minimum of 3 minutes from now
             const minimumReminderInterval = (new Date(Date.now() + (3 * 60 * 1000)));
             // Maximum of 30 years from now
-            const maximumReminderInterval = (new Date((d => d.setFullYear(d.getFullYear() + 30))(new Date)));
+            const maximumReminderInterval = new Date((new Date).setFullYear((new Date).getFullYear() + 30));
 
             if (reminderTime >= maximumReminderInterval) {
                 return {

--- a/src/factory.service.js
+++ b/src/factory.service.js
@@ -26,7 +26,15 @@ const makeService = (cache, twitter, notifications) => {
             const reminderTime = mainResult.start.date();
             // Minimum of 3 minutes from now
             const minimumReminderInterval = (new Date(Date.now() + (3 * 60 * 1000)));
-            if (reminderTime >= minimumReminderInterval) {
+            // Maximum of 30 years from now
+            const maximumReminderInterval = (new Date((d => d.setFullYear(d.getFullYear() + 30))(new Date)));
+
+            if (reminderTime >= maximumReminderInterval) {
+                return {
+                    failure: "TIME_IN_FAR_FUTURE",
+                    tweet
+                };
+            } else if (reminderTime >= minimumReminderInterval) {
                 return {
                     remindAt: reminderTime,
                     refDate,

--- a/tests/unit/service.test.js
+++ b/tests/unit/service.test.js
@@ -43,6 +43,15 @@ test("doesn't set for time in past", async () => {
     expect(parsingResult.failure).toBe("TIME_IN_PAST");
 });
 
+test("doesn't set for time in far future (>=30 years)", async () => {
+    parsingResult = await parseReminderTime(createMention({text: "@RemindMe_OfThis Jan 2100"}));
+    expect(parsingResult.failure).toBe("TIME_IN_FAR_FUTURE");
+
+    parsingResult = await parseReminderTime(createMention({text: "@RemindMe_OfThis in 1000 years"}));
+    console.log(parsingResult);
+    expect(parsingResult.failure).toBe("TIME_IN_FAR_FUTURE");
+});
+
 test("picks time after the last mention", async () => {
     parsingResult = await parseReminderTime(createMention({
         text: "@RemindMe_OfThis next month @RemindMe_OfThis five minutes",

--- a/tests/unit/service.test.js
+++ b/tests/unit/service.test.js
@@ -39,7 +39,6 @@ test("doesn't set for time in past", async () => {
     expect(parsingResult.failure).toBe("TIME_IN_PAST");
 
     parsingResult = await parseReminderTime(createMention({text: "@RemindMe_OfThis January 2018"}));
-    console.log(parsingResult);
     expect(parsingResult.failure).toBe("TIME_IN_PAST");
 });
 
@@ -48,7 +47,6 @@ test("doesn't set for time in far future (>=30 years)", async () => {
     expect(parsingResult.failure).toBe("TIME_IN_FAR_FUTURE");
 
     parsingResult = await parseReminderTime(createMention({text: "@RemindMe_OfThis in 1000 years"}));
-    console.log(parsingResult);
     expect(parsingResult.failure).toBe("TIME_IN_FAR_FUTURE");
 });
 


### PR DESCRIPTION
Nice one open-sourcing this btw @shalvah 👍🏾 

Here are the changes:
- added maximumReminderInterval and a conditional for it
- added a test for 1000 years and Jan 2100 😀 (The world would be a different place, very unlikely Twitter will still be a thing and we'd be super lucky to be alive) 

I'm not super sure you'd like the anonymous function for getting the future time but I think it's cleaner versus adding more figures, dealing with leap years etc; please let me know if there's a better alternative or if I need to change anything